### PR TITLE
rebase of #5287 onto release 1.5.2

### DIFF
--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -228,6 +228,7 @@ private:
 	orb_advert_t		_to_safety;
 
 	float _mot_t_max;	// maximum rise time for motor (slew rate limiting)
+	float _thr_mdl_fac;	// thrust to pwm modelling factor
 
 	static bool	arm_nothrottle()
 	{
@@ -1100,6 +1101,10 @@ PX4FMU::cycle()
 				_mixers->set_max_delta_out_once(delta_out_max);
 			}
 
+			if (_thr_mdl_fac > FLT_EPSILON) {
+				_mixers->set_thrust_factor(_thr_mdl_fac);
+			}
+
 			/* do mixing */
 			float outputs[_max_actuators];
 			num_outputs = _mixers->mix(outputs, num_outputs, NULL);
@@ -1243,6 +1248,13 @@ PX4FMU::cycle()
 
 		if (param_handle != PARAM_INVALID) {
 			param_get(param_handle, &_mot_t_max);
+		}
+
+		// thrust to pwm modelling factor
+		param_handle = param_find("THR_MDL_FAC");
+
+		if (param_handle != PARAM_INVALID) {
+			param_get(param_handle, &_thr_mdl_fac);
 		}
 	}
 

--- a/src/drivers/px4fmu/fmu.cpp
+++ b/src/drivers/px4fmu/fmu.cpp
@@ -944,6 +944,7 @@ PX4FMU::cycle()
 #endif
 #endif
 		param_find("MOT_SLEW_MAX");
+		param_find("THR_MDL_FAC");
 
 		_initialized = true;
 	}

--- a/src/drivers/px4io/px4io.cpp
+++ b/src/drivers/px4io/px4io.cpp
@@ -1271,6 +1271,14 @@ PX4IO::task_main()
 					}
 				}
 
+				/* thrust to pwm modelling factor */
+				parm_handle = param_find("THR_MDL_FAC");
+
+				if (parm_handle != PARAM_INVALID) {
+					param_get(parm_handle, &param_val);
+					(void)io_reg_set(PX4IO_PAGE_SETUP, PX4IO_P_SETUP_THR_MDL_FAC, FLOAT_TO_REG(param_val));
+				}
+
 				/* maximum motor pwm slew rate */
 				parm_handle = param_find("MOT_SLEW_MAX");
 

--- a/src/modules/px4iofirmware/mixer.cpp
+++ b/src/modules/px4iofirmware/mixer.cpp
@@ -241,7 +241,13 @@ mixer_tick(void)
 		}
 
 		/* mix */
+		/* update parameter for mc thrust model if it updated */
+		if (update_mc_thrust_param) {
+			mixer_group.set_thrust_factor(REG_TO_FLOAT(r_setup_thr_fac));
+			update_mc_thrust_param = false;
+		}
 
+		/* mix */
 		/* poor mans mutex */
 		in_mixer = true;
 		mixed = mixer_group.mix(&outputs[0], PX4IO_SERVO_COUNT, &r_mixer_limits);
@@ -527,6 +533,12 @@ mixer_set_failsafe()
 		float delta_out_max = 2.0f * 1000.0f * dt / (r_page_servo_control_max[0] - r_page_servo_control_min[0]) / REG_TO_FLOAT(
 					      r_setup_slew_max);
 		mixer_group.set_max_delta_out_once(delta_out_max);
+	}
+
+	/* update parameter for mc thrust model if it updated */
+	if (update_mc_thrust_param) {
+		mixer_group.set_thrust_factor(REG_TO_FLOAT(r_setup_thr_fac));
+		update_mc_thrust_param = false;
 	}
 
 	/* mix */

--- a/src/modules/px4iofirmware/protocol.h
+++ b/src/modules/px4iofirmware/protocol.h
@@ -244,7 +244,9 @@ enum {							/* DSM bind states */
 
 #define PX4IO_P_SETUP_MOTOR_SLEW_MAX		24 	/* max motor slew rate */
 
-#define PX4IO_P_SETUP_THERMAL			25	/* thermal management */
+#define PX4IO_P_SETUP_THR_MDL_FAC 		25	/* factor for modelling static pwm output to thrust relationship */
+
+#define PX4IO_P_SETUP_THERMAL			26	/* thermal management */
 #define PX4IO_THERMAL_IGNORE			UINT16_MAX
 #define PX4IO_THERMAL_OFF			0
 #define PX4IO_THERMAL_FULL			10000

--- a/src/modules/px4iofirmware/px4io.h
+++ b/src/modules/px4iofirmware/px4io.h
@@ -126,6 +126,7 @@ extern uint16_t			r_page_servo_disarmed[];	/* PX4IO_PAGE_DISARMED_PWM */
 #define r_setup_scale_pitch	r_page_setup[PX4IO_P_SETUP_SCALE_PITCH]
 #define r_setup_scale_yaw	r_page_setup[PX4IO_P_SETUP_SCALE_YAW]
 #define r_setup_sbus_rate	r_page_setup[PX4IO_P_SETUP_SBUS_RATE]
+#define r_setup_thr_fac		r_page_setup[PX4IO_P_SETUP_THR_MDL_FAC]
 #define r_setup_slew_max	r_page_setup[PX4IO_P_SETUP_MOTOR_SLEW_MAX]
 
 #define r_control_values	(&r_page_controls[0])
@@ -147,6 +148,7 @@ struct sys_state_s {
 
 extern struct sys_state_s system_state;
 extern float dt;
+extern bool update_mc_thrust_param;
 
 /*
  * PWM limit structure

--- a/src/modules/px4iofirmware/registers.c
+++ b/src/modules/px4iofirmware/registers.c
@@ -56,6 +56,7 @@
 static int	registers_set_one(uint8_t page, uint8_t offset, uint16_t value);
 static void	pwm_configure_rates(uint16_t map, uint16_t defaultrate, uint16_t altrate);
 
+bool update_mc_thrust_param;
 /**
  * PAGE 0
  *
@@ -182,6 +183,7 @@ volatile uint16_t	r_page_setup[] = {
 	[PX4IO_P_SETUP_SCALE_PITCH] = 10000,
 	[PX4IO_P_SETUP_SCALE_YAW] = 10000,
 	[PX4IO_P_SETUP_MOTOR_SLEW_MAX] = 0,
+	[PX4IO_P_SETUP_THR_MDL_FAC] = 0,
 	[PX4IO_P_SETUP_THERMAL] = PX4IO_THERMAL_IGNORE
 };
 
@@ -687,12 +689,14 @@ registers_set_one(uint8_t page, uint8_t offset, uint16_t value)
 		case PX4IO_P_SETUP_SCALE_ROLL:
 		case PX4IO_P_SETUP_SCALE_PITCH:
 		case PX4IO_P_SETUP_SCALE_YAW:
+		case PX4IO_P_SETUP_MOTOR_SLEW_MAX:
 		case PX4IO_P_SETUP_SBUS_RATE:
 			r_page_setup[offset] = value;
 			sbus1_set_output_rate_hz(value);
 			break;
 
-		case PX4IO_P_SETUP_MOTOR_SLEW_MAX:
+		case PX4IO_P_SETUP_THR_MDL_FAC:
+			update_mc_thrust_param = true;
 			r_page_setup[offset] = value;
 			break;
 

--- a/src/modules/sensors/sensor_params.c
+++ b/src/modules/sensors/sensor_params.c
@@ -3278,6 +3278,18 @@ PARAM_DEFINE_INT32(PWM_AUX_MAX, 2000);
 PARAM_DEFINE_INT32(PWM_AUX_DISARMED, 1000);
 
 /**
+ * Thrust to PWM model parameter
+ *
+ * Parameter used to model the relationship between static thrust and motor
+ * input PWM. Model is: thrust = (1-factor)*PWM + factor * PWM^2
+ *
+ * @min 0.0
+ * @max 1.0
+ * @group PWM Outputs
+ */
+PARAM_DEFINE_FLOAT(THR_MDL_FAC, 0.65f);
+
+/**
  * Minimum motor rise time (slew rate limit).
  *
  * Minimum time allowed for the motor input signal to pass through

--- a/src/modules/systemlib/mixer/mixer.h
+++ b/src/modules/systemlib/mixer/mixer.h
@@ -193,6 +193,13 @@ public:
 	virtual void 			set_max_delta_out_once(float delta_out_max) {};
 
 
+	/*
+	 * @brief      Sets the thrust factor used to calculate mapping from desired thrust to pwm.
+	 *
+	 * @param[in]  val   The value
+	 */
+	virtual void 			set_thrust_factor(float val) {};
+
 protected:
 	/** client-supplied callback used when fetching control values */
 	ControlCallback			_control_cb;
@@ -556,8 +563,9 @@ private:
 	float				_pitch_scale;
 	float				_yaw_scale;
 	float				_idle_speed;
-
 	float 				_delta_out_max;
+	float 				_thrust_factor;
+
 
 	orb_advert_t			_limits_pub;
 	multirotor_motor_limits_s 	_limits;

--- a/src/modules/systemlib/mixer/mixer_multirotor.cpp
+++ b/src/modules/systemlib/mixer/mixer_multirotor.cpp
@@ -91,6 +91,7 @@ MultirotorMixer::MultirotorMixer(ControlCallback control_cb,
 	_yaw_scale(yaw_scale),
 	_idle_speed(-1.0f + idle_speed * 2.0f),	/* shift to output range here to avoid runtime calculation */
 	_delta_out_max(0.0f),
+	_thrust_factor(0.0f),
 	_limits_pub(),
 	_rotor_count(_config_rotor_count[(MultirotorGeometryUnderlyingType)geometry]),
 	_rotors(_config_index[(MultirotorGeometryUnderlyingType)geometry]),
@@ -371,6 +372,18 @@ MultirotorMixer::mix(float *outputs, unsigned space, uint16_t *status_reg)
 			      pitch * _rotors[i].pitch_scale) * roll_pitch_scale +
 			     yaw * _rotors[i].yaw_scale +
 			     thrust + boost;
+
+		/*
+			implement simple model for static relationship between applied motor pwm and motor thrust
+			model: thrust = (1 - _thrust_factor) * PWM + _thrust_factor * PWM^2
+			this model assumes normalized input / output in the range [0,1] so this is the right place
+			to do it as at this stage the outputs are in that range.
+		 */
+		if (_thrust_factor > 0.0f) {
+			outputs[i] = -(1.0f - _thrust_factor) / (2.0f * _thrust_factor) + sqrtf((1.0f - _thrust_factor) *
+					(1.0f - _thrust_factor) / (4.0f * _thrust_factor * _thrust_factor) + (outputs[i] < 0.0f ? 0.0f : outputs[i] /
+							_thrust_factor));
+		}
 
 		outputs[i] = constrain(_idle_speed + (outputs[i] * (1.0f - _idle_speed)), _idle_speed, 1.0f);
 


### PR DESCRIPTION
flight testing on QAV250 shows no obvious reduction of oscillation at high throttle:

roll oscillations at hover and full throttle with THR_MDL_FAC = 0.65 (note also the higher hover throttle)
http://review.px4.io/plot_app?log=b5c14343-7a66-410f-ad58-bf512efccf98

![maxthr](https://cloud.githubusercontent.com/assets/2300221/21247852/fb403a58-c2ef-11e6-9a8d-b8abc5d11a58.png)

suppression of oscillations using v1.5.2 TPA with breakpoint 0.3, slope 1.5:
http://review.px4.io/plot_app?log=e7650549-dccc-4184-ab6c-03d6636ab555

![maxthr](https://cloud.githubusercontent.com/assets/2300221/21247888/40843a24-c2f0-11e6-849f-6928368d1762.png)
